### PR TITLE
Synchronisation and logging fixes

### DIFF
--- a/src/main/scala/nl/tudelft/fruitarian/observers/BasicLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/BasicLogger.scala
@@ -1,6 +1,6 @@
 package nl.tudelft.fruitarian.observers
 
-import nl.tudelft.fruitarian.p2p.messages.{FruitarianMessage, NextRoundMessage, TextMessage, TransmitMessage, TransmitRequest}
+import nl.tudelft.fruitarian.p2p.messages.{FruitarianMessage, NextRoundMessage, ResultMessage, TextMessage, TransmitMessage, TransmitRequest}
 import nl.tudelft.fruitarian.patterns.Observer
 
 /* Example Observer that logs all incoming messages. */
@@ -12,7 +12,11 @@ object BasicLogger extends Observer[FruitarianMessage] {
 
   def receiveUpdate(event: FruitarianMessage): Unit = event match {
     case TextMessage(from, _, message) => stripZeroBytes(message) match {
-      case s if s.length > 0 => println(s"[${from.socket}][TEXT]: $message")
+      case s if s.nonEmpty => println(s"[${from.socket}][TEXT]: $message")
+      case _ =>
+    }
+    case ResultMessage(from, _, message) => stripZeroBytes(message) match {
+      case s if s.nonEmpty => println(s"[${from.socket}][RESULT]: $message -- " + message(0))
       case _ =>
     }
     case TransmitRequest(from, _, roundId) => println(s"[${from.socket}][R$roundId][MESSAGE_REQUEST]")

--- a/src/main/scala/nl/tudelft/fruitarian/observers/BasicLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/BasicLogger.scala
@@ -6,17 +6,17 @@ import nl.tudelft.fruitarian.patterns.Observer
 /* Example Observer that logs all incoming messages. */
 object BasicLogger extends Observer[FruitarianMessage] {
 
-  def stripZeroBytes(message: String): String = {
-    message.replace(0.toChar, ' ').strip()
+  def stripNonReadableBytes(message: String): String = {
+    message.replaceAll("[^ -~]", "")
   }
 
   def receiveUpdate(event: FruitarianMessage): Unit = event match {
-    case TextMessage(from, _, message) => stripZeroBytes(message) match {
+    case TextMessage(from, _, message) => stripNonReadableBytes(message) match {
       case s if s.nonEmpty => println(s"[${from.socket}][TEXT]: $message")
       case _ =>
     }
-    case ResultMessage(from, _, message) => stripZeroBytes(message) match {
-      case s if s.nonEmpty => println(s"[${from.socket}][RESULT]: $message -- " + message(0))
+    case ResultMessage(from, _, message) => stripNonReadableBytes(message) match {
+      case s if s.nonEmpty => println(s"[${from.socket}][RESULT]: $message")
       case _ =>
     }
     case TransmitRequest(from, _, roundId) => println(s"[${from.socket}][R$roundId][MESSAGE_REQUEST]")

--- a/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
@@ -21,7 +21,7 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
   protected implicit val context: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
   var messageRound: Promise[Boolean] = _
-  val MESSAGE_ROUND_TIMEOUT = 250
+  val MESSAGE_ROUND_TIMEOUT = 5000
   val BACKOFF_RANGE = 10
   val messageQueue = new mutable.Queue[String]()
   var messageSent: String = ""
@@ -140,7 +140,6 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
         // The next round is initiated by sending a message to the new center node.
         // A delay of 500 is set between rounds for testing purposes.
         Future {
-          Thread.sleep(2 * MESSAGE_ROUND_TIMEOUT)
           startNextRound(roundId)
         }
       }

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/messages/ResultMessage.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/messages/ResultMessage.scala
@@ -2,7 +2,7 @@ package nl.tudelft.fruitarian.p2p.messages
 
 import nl.tudelft.fruitarian.p2p.Address
 
-case class ResultMessage(from: Address, to: Address, message: String) extends FruitarianMessage(MessageHeader(TextMessage.MessageType, from, to)) {
+case class ResultMessage(from: Address, to: Address, message: String) extends FruitarianMessage(MessageHeader(ResultMessage.MessageType, from, to)) {
   override def serializeBody(): String = message
 }
 


### PR DESCRIPTION
This PR fixes three issues:
- Round numbers would eventually go out of sync which would result in corrupt messages
- `ResultMessage` was not properly being logged
- Limits printing of non-readable characters which caused seemingly empty messages being logged

It also improves performance by removing a round timeout that became unnecessary.