### PR TITLE
Calculate average max bandwidth and setup experiment nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Fruitarian
+
 A clone of the herbivore anonymous communication protocol
 
 ## Running
@@ -11,7 +12,8 @@ Then, simply run:
 python run.py -n 3
 ```
 
-This will build and package the project and start a Fruitarian network with 3 nodes on localhost that connect to each other through subsequent ports.
+This will build and package the project and start a Fruitarian network with 3 nodes on localhost that connect to each other through subsequent ports, with one node running an experiment (i.e. sending random data and measuring various performance metrics).
+The `-e` flag can be used to set the amount of nodes that should be running an experiment.
 The script can also be used to connect to an existing network using the `-j` and `-p` flags to specify which host and port to join respectively.
 If you already have a packaged version of the project and do not want to repackage, you can skip this using the `-s` flag.
 In case you need more information, simply add the `-h` flag.
@@ -22,6 +24,7 @@ We use the LTS version of the JDK which at this point is Java 11.
 Make sure you have Scala and sbt installed.
 
 ### IntelliJ IDEA
+
 Make sure to download the [scala plugin](https://www.jetbrains.com/help/idea/discover-intellij-idea-for-scala.html).
 You might get a popup for this if you open the project without having it installed.
 
@@ -34,9 +37,11 @@ This will help resolve any issues in IntelliJ itself.
 You should now be able to run the project from the main file.
 
 ### Terminal
+
 To run the project in the terminal cd to the root of the project and call `sbt`.
 Once inside the `sbt` terminal you can run the command `run` to run the main project and `test` to run the tests.
 
 ### Pre-Commit
+
 To apply some simple checks before you commit like removing trailing whitespaces, or to forbid you to commit to master you can install [pre-commit](https://pre-commit.com).
 Installation can be done using the command `python3 -m pip install pre-commit` and running `pre-commit install` in the project root folder.

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -18,8 +18,6 @@ object Main extends App {
   handler.addMessageObserver(new EntryObserver(handler, networkInfo))
   var transmissionObserver = new TransmissionObserver(handler, networkInfo)
   handler.addMessageObserver(transmissionObserver)
-  var experimentObserver = new ExperimentObserver(handler, transmissionObserver)
-  handler.addMessageObserver(experimentObserver)
 
   Thread.sleep(1000)
 
@@ -28,6 +26,8 @@ object Main extends App {
 
   if (args.length == 0) {
     // Start first round as first node
+    val experimentObserver = new ExperimentObserver(handler, transmissionObserver)
+    handler.addMessageObserver(experimentObserver)
     transmissionObserver.startMessageRound()
   }
 

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -21,8 +21,8 @@ object Main extends App {
 
   Thread.sleep(1000)
 
-  //transmissionObserver.queueMessage(s"Hi there from ${networkInfo.ownAddress
-  //  .socket.getPort}")
+//  transmissionObserver.queueMessage(s"Hi there from ${networkInfo.ownAddress
+//    .socket.getPort}")
 
   if (args.length == 0) {
     // Start first round as first node

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -11,7 +11,11 @@ object Main extends App {
   /* This example will start a Transmission Message Round with itself. */
   val networkInfo = new NetworkInfo()
 
-  val handler = if (args.length == 0) new TCPHandler() else new TCPHandler(args(0).toInt)
+  val experimentNode = args.contains("-e")
+  val experimentStartingNode = args.length == 1 && experimentNode
+  val startingNode = args.length == 0 || experimentStartingNode
+
+  val handler = if (startingNode) new TCPHandler() else new TCPHandler(args(0).toInt)
   networkInfo.ownAddress = Address(handler.serverHost)
   handler.addMessageObserver(BasicLogger)
   handler.addMessageObserver(new Greeter(handler))
@@ -24,15 +28,18 @@ object Main extends App {
 //  transmissionObserver.queueMessage(s"Hi there from ${networkInfo.ownAddress
 //    .socket.getPort}")
 
-  if (args.length == 0) {
+  if (startingNode) {
     // Start first round as first node
-    val experimentObserver = new ExperimentObserver(handler, transmissionObserver)
-    handler.addMessageObserver(experimentObserver)
     transmissionObserver.startMessageRound()
   }
 
+  if (experimentNode) {
+    val experimentObserver = new ExperimentObserver(handler, transmissionObserver)
+    handler.addMessageObserver(experimentObserver)
+  }
+
   // If we are a client node.
-  if (args.length > 0) {
+  if (!startingNode) {
     val helloWorldMessage = EntryRequest(
       Address(handler.serverHost),
       Address(new InetSocketAddress(args(1), args(2).toInt)),

--- a/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
@@ -19,9 +19,9 @@ import scala.util.{Random, Try}
  */
 class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extends Observer[FruitarianMessage] {
   protected implicit val context: ExecutionContextExecutorService =
-    ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(16))
+    ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1))
   var messageRound: Promise[Boolean] = _
-  val MESSAGE_ROUND_TIMEOUT = 5000
+  val MESSAGE_ROUND_TIMEOUT = 50
   val BACKOFF_RANGE = 10
   var messageQueue = new mutable.Queue[String]()
   var messageSent: String = ""


### PR DESCRIPTION
This PR adds two major things:

- A bandwidth experiment. It calculates the average maximum bandwidth as observed by a node through the `ExperimentObserver`. It takes the average by comparing the total time that the node is running to the amount of rounds that have past. It is the maximum bandwidth since it is just the amount of bytes per second multiplied by our maximum transfer size (currently 280). The actual bandwidth differs from the theoretical since the former is excluding rounds where a timeout occurred.
- An `-e` flag, which sets the number of nodes that should be running an experiment (i.e. `ExperimentObserver`). If left unspecified, it will run with one experiment node.

Closes #21 