### PR TITLE
Chat Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,6 @@ Using a slower rounds allows new nodes to catch up.
 
 The chat mode is activated by using the `--chat` flag.
 Or when you are joining another node `<ownport> <other-node-ip> <their-port> --chat` (for example `5000 192.168.1.2 5000 --chat`).
-The chat mode will disable all logging as it uses the terminal to interact with the application.
+Since the chat mode takes over the terminal it will log all logs to the file `application.log`.
+Each start is logged with a timestamp like so: `[START] 2020-04-07 11:30`
 Type the command `/help` to view all the possible commands.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,17 @@ Once inside the `sbt` terminal you can run the command `run` to run the main pro
 
 To apply some simple checks before you commit like removing trailing whitespaces, or to forbid you to commit to master you can install [pre-commit](https://pre-commit.com).
 Installation can be done using the command `python3 -m pip install pre-commit` and running `pre-commit install` in the project root folder.
+
+## Chat
+For demonstration purposes the application contains a chat mode that uses the `ChatLogger` observer.
+This sets up the application to act as an inbox based chat (more like email).
+Each node in the clique is able to send a message which will be received anonymously by all nodes in this clique (including the sender).
+
+This mode significantly slows down the rounds to allow easy syncing of the random generators for each node.
+This is because these random generators have to be in sync with the roundId to work (see `models.Peer` class).
+Using a slower rounds allows new nodes to catch up.
+
+The chat mode is activated by using the `--chat` flag.
+Or when you are joining another node `<ownport> <other-node-ip> <their-port> --chat` (for example `5000 192.168.1.2 5000 --chat`).
+The chat mode will disable all logging as it uses the terminal to interact with the application.
+Type the command `/help` to view all the possible commands.

--- a/src/main/scala/nl/tudelft/fruitarian/Logger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Logger.scala
@@ -1,7 +1,8 @@
 package nl.tudelft.fruitarian
 
 import java.io.{BufferedWriter, File, FileWriter}
-import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 
 object Logger {
@@ -29,7 +30,7 @@ object Logger {
   def setLogToFile(): Unit = {
     logFile = new File("application.log")
     logFileWriter = new BufferedWriter(new FileWriter(logFile))
-    logFileWriter.write(s"[START] ${LocalDate.now().toString}")
+    logFileWriter.write(s"[START] ${LocalDateTime.now().format(DateTimeFormatter.ofPattern("YYYY-MM-dd HH:mm"))}")
     logFileWriter.newLine()
     logAction = logToFile
   }

--- a/src/main/scala/nl/tudelft/fruitarian/Logger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Logger.scala
@@ -1,0 +1,19 @@
+package nl.tudelft.fruitarian
+
+
+
+object Logger {
+  object Level extends Enumeration {
+    type level = Value
+    val INFO, DEBUG, ERROR = Value
+  }
+  import Level._
+
+  var logLevels: Seq[Level.Value] = List(INFO, DEBUG, ERROR)
+
+  def log(msg: String, lvl: Level.Value): Unit = {
+    if (logLevels.contains(lvl)){
+      println(s"[$lvl] $msg")
+    }
+  }
+}

--- a/src/main/scala/nl/tudelft/fruitarian/Logger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Logger.scala
@@ -1,5 +1,7 @@
 package nl.tudelft.fruitarian
 
+import java.io.{BufferedWriter, File, FileWriter}
+import java.time.LocalDate
 
 
 object Logger {
@@ -9,11 +11,32 @@ object Logger {
   }
   import Level._
 
+  // The logLevels define which types of logs are acted upon.
   var logLevels: Seq[Level.Value] = List(INFO, DEBUG, ERROR)
+
+  // The logAction defines what happens to each log entry.
+  private var logAction: String => Unit = println
 
   def log(msg: String, lvl: Level.Value): Unit = {
     if (logLevels.contains(lvl)){
-      println(s"[$lvl] $msg")
+      logAction(s"[$lvl] $msg")
     }
+  }
+
+  private var logFile: File = _
+  private var logFileWriter: BufferedWriter = _
+
+  def setLogToFile(): Unit = {
+    logFile = new File("application.log")
+    logFileWriter = new BufferedWriter(new FileWriter(logFile))
+    logFileWriter.write(s"[START] ${LocalDate.now().toString}")
+    logFileWriter.newLine()
+    logAction = logToFile
+  }
+
+  private def logToFile(msg: String): Unit = {
+    logFileWriter.write(msg)
+    logFileWriter.newLine()
+    logFileWriter.flush()
   }
 }

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -27,6 +27,7 @@ object Main extends App {
   var transmissionObserver = new TransmissionObserver(handler, networkInfo)
   handler.addMessageObserver(transmissionObserver)
 
+  // Give the TCP Handler some time to start up.
   Thread.sleep(1000)
 
   if (chatNode) {
@@ -36,26 +37,25 @@ object Main extends App {
     handler.addMessageObserver(new ChatLogger(transmissionObserver))
   }
 
-  if (startingNode) {
-    // Start first round as first node
-    transmissionObserver.startMessageRound()
-  }
 
   if (experimentNode) {
     val experimentObserver = new ExperimentObserver(handler, transmissionObserver)
     handler.addMessageObserver(experimentObserver)
   }
 
-  // If we are a client node.
-  if (!startingNode) {
-    val helloWorldMessage = EntryRequest(
+  if (startingNode) {
+    // If we are a startingNode, start first round.
+    transmissionObserver.startMessageRound()
+  } else {
+    // If we are a client node, send EntryRequest to known node given in the
+    // arguments.
+    handler.sendMessage(EntryRequest(
       Address(handler.serverHost),
       Address(new InetSocketAddress(args(1), args(2).toInt)),
-      networkInfo.nodeId)
-
-    handler.sendMessage(helloWorldMessage)
+      networkInfo.nodeId))
   }
 
+  // On application shutdown, shutdown the handler.
   sys.addShutdownHook(() => {
     handler.shutdown()
   })

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -31,8 +31,6 @@ object Main extends App {
     Logger.logLevels = List(Logger.Level.ERROR)
     handler.addMessageObserver(new ChatLogger(transmissionObserver))
   }
-//  transmissionObserver.queueMessage(s"Hi there from ${networkInfo.ownAddress
-//    .socket.getPort}")
 
   if (startingNode) {
     // Start first round as first node

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -58,5 +58,5 @@ object Main extends App {
   }
 
   // On application shutdown, shutdown the handler.
-  sys.addShutdownHook(handler.shutdown)
+  sys.addShutdownHook(handler.shutdown())
 }

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -18,8 +18,11 @@ object Main extends App {
   val startingNode = args.length == 0 || experimentStartingNode || chatStartingNode
 
   val handler = if (startingNode) new TCPHandler() else new TCPHandler(args(0).toInt)
-  networkInfo.ownAddress = Address(handler.serverHost)
-  if (!chatNode) handler.addMessageObserver(BasicLogger)
+  if (!chatNode) {
+    // If you are a chatNode you need to set your networkInfo.ownAddress to your machine ip.
+    networkInfo.ownAddress = Address(handler.serverHost)
+    handler.addMessageObserver(BasicLogger)
+  }
   handler.addMessageObserver(new Greeter(handler))
   handler.addMessageObserver(new EntryObserver(handler, networkInfo))
   var transmissionObserver = new TransmissionObserver(handler, networkInfo)

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -29,7 +29,7 @@ object Main extends App {
 
   if (chatNode) {
     // Only log errors in chat mode.
-    Logger.logLevels = List(Logger.Level.ERROR)
+    Logger.logLevels = Nil
     handler.addMessageObserver(new ChatLogger(transmissionObserver))
   }
 

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -30,8 +30,9 @@ object Main extends App {
   Thread.sleep(1000)
 
   if (chatNode) {
-    // Only log errors in chat mode.
+    // Disable logging in Chat mode.
     Logger.logLevels = Nil
+    networkInfo.chatMode = true
     handler.addMessageObserver(new ChatLogger(transmissionObserver))
   }
 

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -12,9 +12,10 @@ object Main extends App {
   val networkInfo = new NetworkInfo()
 
   val experimentNode = args.contains("-e")
-  val experimentStartingNode = args.length == 1 && experimentNode
   val chatNode = args.contains("--chat")
-  val startingNode = args.length == 0 || experimentStartingNode
+  val experimentStartingNode = args.length == 1 && experimentNode
+  val chatStartingNode = args.length == 1 && chatNode
+  val startingNode = args.length == 0 || experimentStartingNode || chatStartingNode
 
   val handler = if (startingNode) new TCPHandler() else new TCPHandler(args(0).toInt)
   networkInfo.ownAddress = Address(handler.serverHost)

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -56,7 +56,5 @@ object Main extends App {
   }
 
   // On application shutdown, shutdown the handler.
-  sys.addShutdownHook(() => {
-    handler.shutdown()
-  })
+  sys.addShutdownHook(handler.shutdown)
 }

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -31,8 +31,8 @@ object Main extends App {
   Thread.sleep(1000)
 
   if (chatNode) {
-    // Disable logging in Chat mode.
-    Logger.logLevels = Nil
+    // Log to file instead of console in chat mode.
+    Logger.setLogToFile()
     networkInfo.chatMode = true
     handler.addMessageObserver(new ChatLogger(transmissionObserver))
   }

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -14,6 +14,7 @@ object Main extends App {
   val experimentNode = args.contains("-e")
   val experimentStartingNode = args.length == 1 && experimentNode
   val chatNode = args.contains("--chat")
+  val startingNode = args.length == 0 || experimentStartingNode
 
   val handler = if (startingNode) new TCPHandler() else new TCPHandler(args(0).toInt)
   networkInfo.ownAddress = Address(handler.serverHost)

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -8,21 +8,20 @@ import nl.tudelft.fruitarian.p2p.messages.EntryRequest
 import nl.tudelft.fruitarian.p2p.{Address, TCPHandler}
 
 object Main extends App {
-  /* This example will start a Transmission Message Round with itself. */
-  val networkInfo = new NetworkInfo()
-
+  // Define behaviour with program arguments.
   val experimentNode = args.contains("-e")
   val chatNode = args.contains("--chat")
   val experimentStartingNode = args.length == 1 && experimentNode
   val chatStartingNode = args.length == 1 && chatNode
   val startingNode = args.length == 0 || experimentStartingNode || chatStartingNode
 
-  val handler = if (startingNode) new TCPHandler() else new TCPHandler(args(0).toInt)
-  if (!chatNode) {
-    // If you are a chatNode you need to set your networkInfo.ownAddress to your machine ip.
-    networkInfo.ownAddress = Address(handler.serverHost)
-    handler.addMessageObserver(BasicLogger)
-  }
+  // Use port 5000 as default server port.
+  val serverPort = if (startingNode) 5000 else args(0).toInt
+
+  val networkInfo = new NetworkInfo(serverPort)
+  val handler = new TCPHandler(serverPort)
+
+  if (!chatNode) handler.addMessageObserver(BasicLogger)
   handler.addMessageObserver(new Greeter(handler))
   handler.addMessageObserver(new EntryObserver(handler, networkInfo))
   var transmissionObserver = new TransmissionObserver(handler, networkInfo)

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -52,7 +52,7 @@ object Main extends App {
     // If we are a client node, send EntryRequest to known node given in the
     // arguments.
     handler.sendMessage(EntryRequest(
-      Address(handler.serverHost),
+      Address(networkInfo.ownAddress.socket),
       Address(new InetSocketAddress(args(1), args(2).toInt)),
       networkInfo.nodeId))
   }

--- a/src/main/scala/nl/tudelft/fruitarian/Main.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/Main.scala
@@ -21,7 +21,7 @@ object Main extends App {
   val networkInfo = new NetworkInfo(serverPort)
   val handler = new TCPHandler(serverPort)
 
-  if (!chatNode) handler.addMessageObserver(BasicLogger)
+  handler.addMessageObserver(BasicLogger)
   handler.addMessageObserver(new Greeter(handler))
   handler.addMessageObserver(new EntryObserver(handler, networkInfo))
   var transmissionObserver = new TransmissionObserver(handler, networkInfo)

--- a/src/main/scala/nl/tudelft/fruitarian/models/DCnet.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/models/DCnet.scala
@@ -117,6 +117,7 @@ object DCnet {
 			case ('0', b) => b
 			case ('1', '1') => '0'
 			case ('1', '0') => '1'
+			case (a, b) => throw new Error(s"Case ($a, $b) not possible");
 		}
 		Integer.parseInt(res.mkString(""), 2).toByte
 	}

--- a/src/main/scala/nl/tudelft/fruitarian/models/DCnet.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/models/DCnet.scala
@@ -101,7 +101,7 @@ object DCnet {
 			})
 		})
 		// The original message.
-		new String(res).replaceAll("""(?m)\s+$""","")
+		new String(res).replaceAll("""[^\s\d\w]""", "").stripTrailing()
 	}
 
 	// Converts a byte into a binary string format.

--- a/src/main/scala/nl/tudelft/fruitarian/models/DCnet.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/models/DCnet.scala
@@ -101,7 +101,7 @@ object DCnet {
 			})
 		})
 		// The original message.
-		new String(res).replaceAll("""[^\s\d\w]""", "").stripTrailing()
+		new String(res).replaceAll("""[^ -~]""", "").stripTrailing()
 	}
 
 	// Converts a byte into a binary string format.

--- a/src/main/scala/nl/tudelft/fruitarian/models/NetworkInfo.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/models/NetworkInfo.scala
@@ -1,15 +1,16 @@
 package nl.tudelft.fruitarian.models
 
-import java.net.InetSocketAddress
+import java.net.{InetAddress, InetSocketAddress}
 
 import nl.tudelft.fruitarian.p2p.Address
 
 import scala.collection.mutable.ArrayBuffer
 
-class NetworkInfo() {
+class NetworkInfo(serverPort: Int) {
   val cliquePeers: ArrayBuffer[Peer] = ArrayBuffer[Peer]()
-  var ownAddress: Address = _
+  var ownAddress: Address = Address(new InetSocketAddress(InetAddress.getLocalHost.getHostAddress, serverPort))
   val nodeId: String = java.util.UUID.randomUUID.toString
+  var chatMode: Boolean = false
 
   // Returns the addresses of all peers.
   def getPeers: List[(String, Address)] = {

--- a/src/main/scala/nl/tudelft/fruitarian/models/NetworkInfo.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/models/NetworkInfo.scala
@@ -1,5 +1,7 @@
 package nl.tudelft.fruitarian.models
 
+import java.net.InetSocketAddress
+
 import nl.tudelft.fruitarian.p2p.Address
 
 import scala.collection.mutable.ArrayBuffer

--- a/src/main/scala/nl/tudelft/fruitarian/observers/BasicLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/BasicLogger.scala
@@ -1,5 +1,6 @@
 package nl.tudelft.fruitarian.observers
 
+import nl.tudelft.fruitarian.Logger
 import nl.tudelft.fruitarian.p2p.messages.{FruitarianMessage, NextRoundMessage, ResultMessage, TextMessage, TransmitMessage, TransmitRequest}
 import nl.tudelft.fruitarian.patterns.Observer
 
@@ -12,16 +13,16 @@ object BasicLogger extends Observer[FruitarianMessage] {
 
   def receiveUpdate(event: FruitarianMessage): Unit = event match {
     case TextMessage(from, _, message) => stripNonReadableBytes(message) match {
-      case s if s.nonEmpty => println(s"[${from.socket}][TEXT]: $message")
+      case s if s.nonEmpty => Logger.log(s"[${from.socket}][TEXT]: $message", Logger.Level.INFO)
       case _ =>
     }
     case ResultMessage(from, _, message) => stripNonReadableBytes(message) match {
-      case s if s.nonEmpty => println(s"[${from.socket}][RESULT]: $message")
+      case s if s.nonEmpty => Logger.log(s"[${from.socket}][RESULT]: $message", Logger.Level.INFO)
       case _ =>
     }
-    case TransmitRequest(from, _, roundId) => println(s"[${from.socket}][R$roundId][MESSAGE_REQUEST]")
-    case TransmitMessage(from, _, (roundId, message)) => println(s"[${from.socket}][R$roundId][BYTE][${message.length}]: 0x${message.map("%02X" format _).mkString.take(40)}...[truncated]")
-    case NextRoundMessage(from, _, roundId) => println(s"[${from.socket}] NEXT ROUND R${roundId}")
-    case _ => println(event)
+    case TransmitRequest(from, _, roundId) => Logger.log(s"[${from.socket}][R$roundId][MESSAGE_REQUEST]", Logger.Level.INFO)
+    case TransmitMessage(from, _, (roundId, message)) => Logger.log(s"[${from.socket}][R$roundId][BYTE][${message.length}]: 0x${message.map("%02X" format _).mkString.take(20)}...[truncated]", Logger.Level.INFO)
+    case NextRoundMessage(from, _, roundId) => Logger.log(s"[${from.socket}] NEXT ROUND R${roundId}", Logger.Level.INFO)
+    case _ => Logger.log(event.toString, Logger.Level.INFO)
   }
 }

--- a/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
@@ -38,6 +38,7 @@ class ChatLogger(transmissionObserver: TransmissionObserver) extends Observer[Fr
     inputFuture.onComplete(msg => {
       if (msg.isSuccess) {
         msg.get match {
+          case "/debug" => println(transmissionObserver.roundId)
           case "/inbox" => renderInbox()
           case "/inbox clear" => clearInbox()
           case "/help" => renderHelp()

--- a/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
@@ -2,6 +2,7 @@ package nl.tudelft.fruitarian.observers
 
 
 import java.time.LocalDate
+import java.util.concurrent.Executors
 
 import nl.tudelft.fruitarian.p2p.messages.{AnnounceMessage, EntryRequest, FruitarianMessage, ResultMessage}
 import nl.tudelft.fruitarian.patterns.Observer
@@ -15,8 +16,7 @@ import scala.io.StdIn.readLine
  * This mode is implemented for demonstration purposes.
  */
 class ChatLogger(transmissionObserver: TransmissionObserver) extends Observer[FruitarianMessage] {
-  protected implicit val context: ExecutionContextExecutor =
-    ExecutionContext.global
+  protected implicit val context: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
   case class ChatMessage(datetime: LocalDate, msg: String)
   def stripNonReadableBytes(msg: String): String = BasicLogger.stripNonReadableBytes(msg)
 

--- a/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
@@ -1,0 +1,90 @@
+package nl.tudelft.fruitarian.observers
+
+
+import java.time.LocalDate
+
+import nl.tudelft.fruitarian.p2p.messages.{FruitarianMessage, ResultMessage}
+import nl.tudelft.fruitarian.patterns.Observer
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.io.StdIn.readLine
+
+
+/**
+ * The Chat logger is used for when the application is in chat mode.
+ * This mode is implemented for demonstration purposes.
+ */
+class ChatLogger(transmissionObserver: TransmissionObserver) extends Observer[FruitarianMessage] {
+  protected implicit val context: ExecutionContextExecutor =
+    ExecutionContext.global
+  case class ChatMessage(datetime: LocalDate, msg: String)
+  def stripNonReadableBytes(msg: String): String = BasicLogger.stripNonReadableBytes(msg)
+
+  val MESSAGE_HISTORY = 5
+  var msgHistory: List[ChatMessage] = Nil
+  var inputFuture: Future[String] = _
+
+  private def renderMessage(msg: ChatMessage): Unit =
+    println(msg.msg)
+  private def requestMessage(): Future[String] = Future {
+    readLine(" > ")
+  }
+
+  /**
+   * Render a simple menu that allows
+   */
+  def renderMenu(): Unit = {
+    inputFuture = requestMessage()
+    inputFuture.onComplete(msg => {
+      if (msg.isSuccess) {
+        msg.get match {
+          case "/inbox" => renderInbox()
+          case "/inbox clear" => clearInbox()
+          case "/help" => renderHelp()
+          case message if message.startsWith("/send ") =>
+            val actualMessage = message.replace("/send ", "")
+            transmissionObserver.queueMessage(actualMessage)
+          case _ => renderHelp()
+        }
+      }
+      renderMenu()
+    })
+  }
+
+  def renderInbox(): Unit = {
+    if (msgHistory.isEmpty) {
+      println("Nothing here.")
+    } else {
+      println(s"Found ${msgHistory.length} message(s)")
+      msgHistory.foreach(msg => renderMessage(msg))
+    }
+  }
+
+  def renderHelp(): Unit = {
+    println("Help Page for Fruitarian")
+    println("  /inbox\t\t\tShows your inbox")
+    println("  /inbox clear\t\tClears your inbox")
+    println("  /help\t\t\tShows this page")
+    println("  /send <msg>\t\tSends the <msg> to the clique")
+  }
+
+  def clearInbox(): Unit = {
+    msgHistory = Nil
+    println("Inbox cleared!")
+  }
+
+
+  // Initial render with no message received.
+  renderMenu()
+
+  override def receiveUpdate(event: FruitarianMessage): Unit = event match {
+    case ResultMessage(_, _, message) => stripNonReadableBytes(message) match {
+      /* In case we get a non-empty message print it. */
+      case s if !s.isEmpty =>
+        val msg = ChatMessage(LocalDate.now(), s"<Clique>: $s")
+        msgHistory = msgHistory :+ msg
+      case _ =>
+    }
+    case _ =>
+  }
+}

--- a/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
@@ -83,6 +83,7 @@ class ChatLogger(transmissionObserver: TransmissionObserver) extends Observer[Fr
       msgHistory = msgHistory :+ msg
     case ResultMessage(_, _, message) => stripNonReadableBytes(message) match {
       /* In case we get a non-empty message print it. */
+      case "TIMEOUT" =>
       case s if !s.isEmpty =>
         val msg = ChatMessage(LocalDate.now(), s"<Clique>: $s")
         msgHistory = msgHistory :+ msg

--- a/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
@@ -3,7 +3,7 @@ package nl.tudelft.fruitarian.observers
 
 import java.time.LocalDate
 
-import nl.tudelft.fruitarian.p2p.messages.{FruitarianMessage, ResultMessage}
+import nl.tudelft.fruitarian.p2p.messages.{AnnounceMessage, EntryRequest, FruitarianMessage, ResultMessage}
 import nl.tudelft.fruitarian.patterns.Observer
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
@@ -78,6 +78,9 @@ class ChatLogger(transmissionObserver: TransmissionObserver) extends Observer[Fr
   renderMenu()
 
   override def receiveUpdate(event: FruitarianMessage): Unit = event match {
+    case EntryRequest(_, _, _) | AnnounceMessage(_, _, _) =>
+      val msg = ChatMessage(LocalDate.now(), s"<Clique>: Node joined!")
+      msgHistory = msgHistory :+ msg
     case ResultMessage(_, _, message) => stripNonReadableBytes(message) match {
       /* In case we get a non-empty message print it. */
       case s if !s.isEmpty =>

--- a/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/ChatLogger.scala
@@ -2,7 +2,6 @@ package nl.tudelft.fruitarian.observers
 
 
 import java.time.LocalDate
-import java.util.concurrent.Executors
 
 import nl.tudelft.fruitarian.p2p.messages.{AnnounceMessage, EntryRequest, FruitarianMessage, ResultMessage}
 import nl.tudelft.fruitarian.patterns.Observer
@@ -16,7 +15,7 @@ import scala.io.StdIn.readLine
  * This mode is implemented for demonstration purposes.
  */
 class ChatLogger(transmissionObserver: TransmissionObserver) extends Observer[FruitarianMessage] {
-  protected implicit val context: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+  protected implicit val context: ExecutionContextExecutor = ExecutionContext.global
   case class ChatMessage(datetime: LocalDate, msg: String)
   def stripNonReadableBytes(msg: String): String = BasicLogger.stripNonReadableBytes(msg)
 

--- a/src/main/scala/nl/tudelft/fruitarian/observers/EntryObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/EntryObserver.scala
@@ -10,10 +10,6 @@ import scala.util.Random
 class EntryObserver(handler: TCPHandler, networkInfo: NetworkInfo) extends Observer[FruitarianMessage] {
   override def receiveUpdate(event: FruitarianMessage): Unit = event match {
     case EntryRequest(from, to, id) =>
-			// TODO: Find a better way to set our own address. This could allow
-			//  malicious entries as we rely on the sender to set the correct header
-			//  field.
-			networkInfo.ownAddress = to
 	    // Generate and send common seed to entry node.
       val seed = DCnet.getSeed
 	    handler.sendMessage(EntryResponse(to, from, EntryResponseBody(seed.toString, networkInfo.getPeers, networkInfo.nodeId)))

--- a/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
@@ -136,7 +136,7 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
 
 
   override def receiveUpdate(event: FruitarianMessage): Unit = event match {
-    case TransmitRequest(from, to, reqRoundId) =>
+    case TransmitRequest(from, to, reqRoundId) => this.synchronized {
       if (messageQueue.nonEmpty && messageSent.isEmpty && backoff == 0) {
         // If we have a message to send and are not waiting for confirmation
         // of a previous message, send the next message. If we failed to send
@@ -157,6 +157,7 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
       }
       // Decrease the backoff by one until 0.
       backoff = math.max(0, backoff - 1)
+    }
 
     case TransmitMessage(_, _, message) =>
       this.synchronized {

--- a/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
@@ -64,7 +64,7 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
    * which node sent it (see DCNet code).
    */
   def startMessageRound(): Unit = {
-    Thread.sleep(1000)
+    if (networkInfo.chatMode) Thread.sleep(1000)
     // Clear possible remaining responses.
     DCnet.clearResponses()
     roundId += 1

--- a/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
@@ -64,6 +64,7 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
    * which node sent it (see DCNet code).
    */
   def startMessageRound(): Unit = {
+    Thread.sleep(1000)
     // Clear possible remaining responses.
     DCnet.clearResponses()
     roundId += 1

--- a/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
@@ -38,13 +38,14 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
    *                   the queue).
    */
   def queueMessage(message: String, prioritise: Boolean = false): Unit = {
-    if (message.length > DCnet.MESSAGE_SIZE) {
+    val processedMessage = message.stripTrailing()
+    if (processedMessage.length > DCnet.MESSAGE_SIZE) {
       throw new Exception("Message too long.")
     }
     if (prioritise) {
-      messageQueue = mutable.Queue[String](message) ++ messageQueue
+      messageQueue = mutable.Queue[String](processedMessage) ++ messageQueue
     } else {
-      messageQueue.enqueue(message)
+      messageQueue.enqueue(processedMessage)
     }
   }
 

--- a/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/TransmissionObserver.scala
@@ -1,5 +1,6 @@
 package nl.tudelft.fruitarian.observers
 
+import nl.tudelft.fruitarian.Logger
 import nl.tudelft.fruitarian.models.{DCnet, NetworkInfo}
 import nl.tudelft.fruitarian.p2p.messages._
 import nl.tudelft.fruitarian.p2p.{Address, TCPHandler}
@@ -74,8 +75,8 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
     // Set the amount of requests sent.
     DCnet.transmitRequestsSent = networkInfo.cliquePeers.length + 1
 
-    println(s"[S] [${networkInfo.nodeId}] Started Message round " +
-      s"[R$roundId] for ${DCnet.transmitRequestsSent} node(s).")
+    Logger.log(s"[S] [${networkInfo.nodeId}] Started Message round " +
+      s"[R$roundId] for ${DCnet.transmitRequestsSent} node(s).", Logger.Level.DEBUG)
 
     val timeoutFuture = Future[Boolean] {
       // Save the roundId in which this timeout future started.
@@ -102,7 +103,7 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
       if (!r.get) {
         break;
       }
-      println(s"[S] Message round [$roundId] timed out, retrying...")
+      Logger.log(s"[S] Message round [$roundId] timed out, retrying...", Logger.Level.ERROR)
       // Send a "TIMEOUT" Text message to all peers to let them know the
       // round failed and trigger the message requeue behaviour if one of
       // them actually sent a message this round.
@@ -143,7 +144,7 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
         //  produce nonsense messages in case no one sends an actual encrypted
         //  message.
         messageSent = messageQueue.dequeue()
-        println(s"[C][R$reqRoundId] Sent my message: '$messageSent'")
+        Logger.log(s"[C][R$reqRoundId] Sent my message: '$messageSent'", Logger.Level.DEBUG)
         handler.sendMessage(TransmitMessage(to, from, (reqRoundId, DCnet
           .encryptMessage(messageSent, networkInfo.cliquePeers.toList,
             reqRoundId))))
@@ -184,7 +185,7 @@ class TransmissionObserver(handler: TCPHandler, networkInfo: NetworkInfo) extend
         // another collision.
         queueMessage(messageSent, true)
         backoff = new Random().nextInt(BACKOFF_RANGE)
-        println(s"[C] Message not sent correctly, enqueued again in $backoff cycles.")
+        Logger.log(s"[C] Message not sent correctly, enqueued again in $backoff cycles.", Logger.Level.ERROR)
       }
       // Unblock the message sending process to allow the next message or a resend.
       messageSent = ""

--- a/src/main/scala/nl/tudelft/fruitarian/observers/UtilizationObserver.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/observers/UtilizationObserver.scala
@@ -15,7 +15,7 @@ class UtilizationObserver(handler: TCPHandler, transmissionObserver: Transmissio
 
   var lastMessage = ""
 
-  def sendNewMessage() {
+  def sendNewMessage(): Unit = {
     lastMessage = ExperimentHelper.generateRandomMessage(DCnet.MESSAGE_SIZE)
     transmissionObserver.queueMessage(lastMessage)
     messagesSent += 1

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/MessageSerializer.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/MessageSerializer.scala
@@ -28,7 +28,9 @@ object MessageSerializer {
           case header @ MessageHeader(TransmitMessage.MessageType, _, _) => TransmitMessage.fromHeaderAndBody(header, body)
           case header @ MessageHeader(ResultMessage.MessageType, _, _) => ResultMessage.fromHeaderAndBody(header, body)
           case header @ MessageHeader(NextRoundMessage.MessageType, _, _) => NextRoundMessage.fromHeaderAndBody(header, body)
+          case MessageHeader(msgType, _, _) => throw new Error(s"Unsupported message type: $msgType received.")
         }
+      case _ => throw new Error("Message could not be deserialized.")
     }
   }
 }

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/MessageSerializer.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/MessageSerializer.scala
@@ -2,6 +2,8 @@ package nl.tudelft.fruitarian.p2p
 
 import java.net.InetSocketAddress
 
+import com.fasterxml.jackson.core.JsonParseException
+import nl.tudelft.fruitarian.Logger
 import nl.tudelft.fruitarian.p2p.messages._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
@@ -17,20 +19,24 @@ object MessageSerializer {
   def serializeMsg(msg: FruitarianMessage): String = {
     compact(render(JObject(("header", Extraction.decompose(msg.header)), ("body", JString(msg.serializeBody())))))
   }
-  def deserialize(data: String, from: Address): FruitarianMessage = {
-    parse(data) match {
-      case JObject(("header", h) :: ("body", JString(body)) :: Nil) => h.extract[MessageHeader] match {
-          case header @ MessageHeader(TextMessage.MessageType, _, _) => TextMessage.fromHeaderAndBody(header, body)
-          case header @ MessageHeader(EntryResponse.MessageType, _, _) => EntryResponse.fromHeaderAndBody(header, body)
-          case header @ MessageHeader(EntryRequest.MessageType, _, _) => EntryRequest.fromHeaderAndBody(header, body)
-          case header @ MessageHeader(TransmitRequest.MessageType, _, _) => TransmitRequest.fromHeaderAndBody(header, body)
-          case header @ MessageHeader(AnnounceMessage.MessageType, _, _) => AnnounceMessage.fromHeaderAndBody(header, body)
-          case header @ MessageHeader(TransmitMessage.MessageType, _, _) => TransmitMessage.fromHeaderAndBody(header, body)
-          case header @ MessageHeader(ResultMessage.MessageType, _, _) => ResultMessage.fromHeaderAndBody(header, body)
-          case header @ MessageHeader(NextRoundMessage.MessageType, _, _) => NextRoundMessage.fromHeaderAndBody(header, body)
+  def deserialize(data: String): FruitarianMessage = {
+    try {
+      parse(data) match {
+        case JObject(("header", h) :: ("body", JString(body)) :: Nil) => h.extract[MessageHeader] match {
+          case header@MessageHeader(TextMessage.MessageType, _, _) => TextMessage.fromHeaderAndBody(header, body)
+          case header@MessageHeader(EntryResponse.MessageType, _, _) => EntryResponse.fromHeaderAndBody(header, body)
+          case header@MessageHeader(EntryRequest.MessageType, _, _) => EntryRequest.fromHeaderAndBody(header, body)
+          case header@MessageHeader(TransmitRequest.MessageType, _, _) => TransmitRequest.fromHeaderAndBody(header, body)
+          case header@MessageHeader(AnnounceMessage.MessageType, _, _) => AnnounceMessage.fromHeaderAndBody(header, body)
+          case header@MessageHeader(TransmitMessage.MessageType, _, _) => TransmitMessage.fromHeaderAndBody(header, body)
+          case header@MessageHeader(ResultMessage.MessageType, _, _) => ResultMessage.fromHeaderAndBody(header, body)
+          case header@MessageHeader(NextRoundMessage.MessageType, _, _) => NextRoundMessage.fromHeaderAndBody(header, body)
           case MessageHeader(msgType, _, _) => throw new Error(s"Unsupported message type: $msgType received.")
         }
-      case _ => throw new Error("Message could not be deserialized.")
+        case _ => throw new Error("Message could not be deserialized.")
+      }
+    } catch {
+      case e: JsonParseException => throw new Error(s"Unable to parse message json: ${e.toString}")
     }
   }
 }

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/MessageSerializer.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/MessageSerializer.scala
@@ -17,18 +17,21 @@ object MessageSerializer {
   def serializeMsg(msg: FruitarianMessage): String = {
     compact(render(JObject(("header", Extraction.decompose(msg.header)), ("body", JString(msg.serializeBody())))))
   }
-  def deserialize(data: String): FruitarianMessage = {
+  def deserialize(data: String, from: Address): FruitarianMessage = {
     parse(data) match {
-      case JObject(("header", h) :: ("body", JString(body)) :: Nil) => h.extract[MessageHeader] match {
-        case header @ MessageHeader(TextMessage.MessageType, _, _) => TextMessage.fromHeaderAndBody(header, body)
-        case header @ MessageHeader(EntryResponse.MessageType, _, _) => EntryResponse.fromHeaderAndBody(header, body)
-        case header @ MessageHeader(EntryRequest.MessageType, _, _) => EntryRequest.fromHeaderAndBody(header, body)
-        case header @ MessageHeader(TransmitRequest.MessageType, _, _) => TransmitRequest.fromHeaderAndBody(header, body)
-        case header @ MessageHeader(AnnounceMessage.MessageType, _, _) => AnnounceMessage.fromHeaderAndBody(header, body)
-        case header @ MessageHeader(TransmitMessage.MessageType, _, _) => TransmitMessage.fromHeaderAndBody(header, body)
-        case header @ MessageHeader(ResultMessage.MessageType, _, _) => ResultMessage.fromHeaderAndBody(header, body)
-        case header @ MessageHeader(NextRoundMessage.MessageType, _, _) => NextRoundMessage.fromHeaderAndBody(header, body)
-      }
+      case JObject(("header", h) :: ("body", JString(body)) :: Nil) =>
+        val header = h.extract[MessageHeader]
+        header.from = from
+        header match {
+          case header @ MessageHeader(TextMessage.MessageType, _, _) => TextMessage.fromHeaderAndBody(header, body)
+          case header @ MessageHeader(EntryResponse.MessageType, _, _) => EntryResponse.fromHeaderAndBody(header, body)
+          case header @ MessageHeader(EntryRequest.MessageType, _, _) => EntryRequest.fromHeaderAndBody(header, body)
+          case header @ MessageHeader(TransmitRequest.MessageType, _, _) => TransmitRequest.fromHeaderAndBody(header, body)
+          case header @ MessageHeader(AnnounceMessage.MessageType, _, _) => AnnounceMessage.fromHeaderAndBody(header, body)
+          case header @ MessageHeader(TransmitMessage.MessageType, _, _) => TransmitMessage.fromHeaderAndBody(header, body)
+          case header @ MessageHeader(ResultMessage.MessageType, _, _) => ResultMessage.fromHeaderAndBody(header, body)
+          case header @ MessageHeader(NextRoundMessage.MessageType, _, _) => NextRoundMessage.fromHeaderAndBody(header, body)
+        }
     }
   }
 }

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/MessageSerializer.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/MessageSerializer.scala
@@ -19,10 +19,7 @@ object MessageSerializer {
   }
   def deserialize(data: String, from: Address): FruitarianMessage = {
     parse(data) match {
-      case JObject(("header", h) :: ("body", JString(body)) :: Nil) =>
-        val header = h.extract[MessageHeader]
-        header.from = from
-        header match {
+      case JObject(("header", h) :: ("body", JString(body)) :: Nil) => h.extract[MessageHeader] match {
           case header @ MessageHeader(TextMessage.MessageType, _, _) => TextMessage.fromHeaderAndBody(header, body)
           case header @ MessageHeader(EntryResponse.MessageType, _, _) => EntryResponse.fromHeaderAndBody(header, body)
           case header @ MessageHeader(EntryRequest.MessageType, _, _) => EntryRequest.fromHeaderAndBody(header, body)

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/TCPHandler.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/TCPHandler.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import nl.tudelft.fruitarian.p2p.messages.FruitarianMessage
 import nl.tudelft.fruitarian.patterns.Observer
 
-class TCPHandler(serverPort: Int = 5000) {
+class TCPHandler(serverPort: Int) {
   // Bind to the machine on the given port.
   val serverHost = new InetSocketAddress("0.0.0.0", serverPort)
 

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/Client.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/Client.scala
@@ -60,9 +60,7 @@ class Client(remote: InetSocketAddress, callback: FruitarianMessage => Unit) ext
 
         // When data received, send it to the listener.
         case Received(data: ByteString) =>
-          val msg: FruitarianMessage = MessageSerializer.deserialize(data.decodeString("utf-8"))
-          // Set the msg header from field to the actual receiver value.
-          msg.header.from = Address(remote)
+          val msg: FruitarianMessage = MessageSerializer.deserialize(data.decodeString("utf-8"), Address(remote))
           callback(msg)
 
         // On close command.

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/Client.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/Client.scala
@@ -6,6 +6,7 @@ import akka.actor.{Actor, ActorSystem, Props}
 import akka.io.Tcp._
 import akka.io.{IO, Tcp}
 import akka.util.ByteString
+import nl.tudelft.fruitarian.Logger
 import nl.tudelft.fruitarian.p2p.messages.FruitarianMessage
 import nl.tudelft.fruitarian.p2p.{Address, MessageSerializer, SendMsg}
 
@@ -47,7 +48,7 @@ class Client(remote: InetSocketAddress, callback: FruitarianMessage => Unit) ext
       queue.foreach((msg: FruitarianMessage) => connection ! Client.messageToWrite(msg))
       queue = Nil
 
-      println(s"[C] Connection established to [$remote]")
+      Logger.log(s"[C] Connection established to [$remote]", Logger.Level.INFO)
 
       context.become {
         // Upon getting binary data, send it through the connection.
@@ -55,7 +56,7 @@ class Client(remote: InetSocketAddress, callback: FruitarianMessage => Unit) ext
           connection ! Client.messageToWrite(msg)
 
         // If the write failed due to OS buffer being full.
-        case CommandFailed(w: Write) => println("[C] Write Failed")
+        case CommandFailed(w: Write) => Logger.log("[C] Write Failed", Logger.Level.ERROR)
 
         // When data received, send it to the listener.
         case Received(data: ByteString) =>
@@ -69,7 +70,7 @@ class Client(remote: InetSocketAddress, callback: FruitarianMessage => Unit) ext
 
         // Upon receiving the close message.
         case _: ConnectionClosed =>
-          println(s"[C] Connection Closed with [$remote]")
+          Logger.log(s"[C] Connection Closed with [$remote]", Logger.Level.INFO)
           context.stop(self)
       }
   }

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/ConnectionHandler.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/ConnectionHandler.scala
@@ -3,6 +3,7 @@ package nl.tudelft.fruitarian.p2p.tcp
 import java.net.InetSocketAddress
 
 import akka.actor.{Actor, ActorRef, Props}
+import nl.tudelft.fruitarian.Logger
 import nl.tudelft.fruitarian.p2p.messages.FruitarianMessage
 import nl.tudelft.fruitarian.p2p.{Address, MessageSerializer, SendMsg}
 
@@ -25,7 +26,7 @@ class ConnectionHandler(connection: ActorRef, remote: InetSocketAddress, callbac
 
     // When the TCP connection is closed, kill this node.
     case PeerClosed =>
-      println("[S] Client connection closed")
+      Logger.log("[S] Client connection closed", Logger.Level.INFO)
       context.stop(self)
 
     // Send any other event to the listener.

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/ConnectionHandler.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/ConnectionHandler.scala
@@ -31,8 +31,7 @@ class ConnectionHandler(connection: ActorRef, remote: InetSocketAddress, callbac
 
     // Send any other event to the listener.
     case Received(data) =>
-      val msg = MessageSerializer.deserialize(data.decodeString("utf-8"))
-      msg.header.from = Address(remote)
+      val msg = MessageSerializer.deserialize(data.decodeString("utf-8"), Address(remote))
       callback(msg)
   }
 }

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/ConnectionHandler.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/ConnectionHandler.scala
@@ -30,8 +30,6 @@ class ConnectionHandler(connection: ActorRef, remote: InetSocketAddress, callbac
       context.stop(self)
 
     // Send any other event to the listener.
-    case Received(data) =>
-      val msg = MessageSerializer.deserialize(data.decodeString("utf-8"), Address(remote))
-      callback(msg)
+    case Received(data) => Client.onMessageReceived(data, callback)
   }
 }

--- a/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/Server.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/p2p/tcp/Server.scala
@@ -5,6 +5,7 @@ import java.net.InetSocketAddress
 import akka.actor.{Actor, ActorSystem, Props}
 import akka.io.Tcp._
 import akka.io.{IO, Tcp}
+import nl.tudelft.fruitarian.Logger
 import nl.tudelft.fruitarian.p2p.messages.FruitarianMessage
 import nl.tudelft.fruitarian.p2p.{Address, Connections, TCPConnection}
 
@@ -31,7 +32,7 @@ class Server(host: InetSocketAddress, callback: FruitarianMessage => Unit) exten
   def receive: Receive = {
     // When the bound to our IO(Tcp) listener is completed.
     case b @ Bound(localAddress) =>
-      println(s"[S] Listening on [$localAddress]")
+      Logger.log(s"[S] Listening on [$localAddress]", Logger.Level.INFO)
 
     // When the bound to our IO(Tcp) listener failed.
     case CommandFailed(_: Bind) => context.stop(self)
@@ -42,7 +43,7 @@ class Server(host: InetSocketAddress, callback: FruitarianMessage => Unit) exten
       val connection = sender()
       val handler = context.actorOf(ConnectionHandler.props(connection, remote, callback))
       connection ! Register(handler)
-      println(s"[S] Client connected from [$remote]")
+      Logger.log(s"[S] Client connected from [$remote]", Logger.Level.INFO)
       Connections.addConnection(TCPConnection(Address(remote), handler))
   }
 }

--- a/src/main/scala/nl/tudelft/fruitarian/patterns/Observer.scala
+++ b/src/main/scala/nl/tudelft/fruitarian/patterns/Observer.scala
@@ -5,5 +5,5 @@ package nl.tudelft.fruitarian.patterns
  * @tparam S The type of objects to expect updates about.
  */
 trait Observer[S] {
-  def receiveUpdate(event: S);
+  def receiveUpdate(event: S): Unit
 }


### PR DESCRIPTION
Resolves #26 

- Removes all sbt compile warnings.
- Introduces a `Logger` object 
  - The object is able to log different levels of information: `DEBUG`, `INFO`, `ERROR`. A list can be set to define which ones should be acted upon.
  - The object is able to log to file (this is used by the chat mode)
- Introduced a chatmode using the `--chat` flag
  - In chat mode the `ChatLogger` presents the user with an inbox based chat application. This application has a simple set of commands, see `/help` for an overview.
  - In chat mode (as it is meant for demonstration of the entire application) the rounds are slowed down to ~1 per second.
- The `NetworkInfo` class now sets its own IP address to the internal network ip automatically using the specified ports (or `5000` by default).


### ChatMode
That sounds all fine and dandy, now how do I get in chat mode you ask?
```bash
# The first node should be started as follows:
sbt "run --chat"

# All nodes joining this node should join as follows:
sbt "run <ownport> <ip-of-node-to-join> <port-of-node-to-join> --chat"
```

You will then enter the chat application, use `/help` for information about the commands. It even works when you are just one node (but that's a bit sad 😢).

### Logs
When in chat mode your logs will be written to file instead of shown in the console. The file used for this is `application.log` in the root of the project. If you want to follow the logs while they occur you can use the command `tail -f application.log` in your terminal. 

The same applies for incoming messages which are stored in the `inbox.log` when you are in chat mode.